### PR TITLE
Bump to ridgepole 0.7.0

### DIFF
--- a/ridgepole-rails.gemspec
+++ b/ridgepole-rails.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 5.0.0"
-  s.add_dependency "ridgepole", "~> 0.6.5"
+  s.add_dependency "ridgepole", "~> 0.7.0"
   s.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
released: https://github.com/winebarrel/ridgepole/releases/tag/v0.7.0