### PR TITLE
Add `--create-table-with-index` option

### DIFF
--- a/lib/ridgepole/rails/rake_task.rb
+++ b/lib/ridgepole/rails/rake_task.rb
@@ -72,7 +72,7 @@ module Ridgepole
 
       class Apply < self
         def command
-          [*RIDGEPOLE_COMMAND, *%w(--apply), *options].shelljoin # rubocop:disable Lint/UnneededSplatExpansion
+          [*RIDGEPOLE_COMMAND, *%w(--apply --create-table-with-index), *options].shelljoin # rubocop:disable Lint/UnneededSplatExpansion
         end
       end
     end

--- a/ridgepole-rails.gemspec
+++ b/ridgepole-rails.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 5.0.0"
-  s.add_dependency "ridgepole", ">= 0.7.0"
+  s.add_dependency "ridgepole", ">= 0.7.1"
   s.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
## Why

https://github.com/winebarrel/ridgepole/tree/v0.7.1

> * `>= 0.7.1`
>   * Remove `--reverse` option
>   * Add `--allow-pk-change` option
>   * Add `--create-table-with-index` option
>   * Add `--mysql-dump-auto-increment` option (`rails >= 5.1`)

## How to check

### Before

ridgepole --apply executes `create_table` and `add_index`.

```
$ bundle exec ridgepole --apply -E development -c config/database.yml --dry-run
Apply `Schemafile` (dry-run)
create_table("hoge", {:id=>:uuid, :default=>proc{"gen_random_uuid()"}}) do |t|
  t.column("user_id", :"uuid", {:null=>false})
  (snip)
  end
add_index("hoge", ["user_id"], {:name=>"index_hoge_on_user_id", :unique=>true})
(snip)
```

### After

ridgepole --apply executes only `create_table`.

```
$ bundle exec ridgepole --apply --create-table-with-index -E development -c config/database.yml --dry-run
Apply `Schemafile` (dry-run)
create_table("hoge", {:id=>:uuid, :default=>proc{"gen_random_uuid()"}}) do |t|
  t.column("user_id", :"uuid", {:null=>false})
  (snip)
  t.index(["user_id"], {:name=>"index_hoge_on_user_id", :unique=>true})
  end
```
